### PR TITLE
added optional genre filtering to top charts function

### DIFF
--- a/lib/src/search/search.dart
+++ b/lib/src/search/search.dart
@@ -90,6 +90,7 @@ class Search {
     Country country = Country.UNITED_KINGDOM,
     int limit = 20,
     bool explicit = false,
+    int genreId,
   }) async {
     _country = country;
     _limit = limit;
@@ -97,7 +98,7 @@ class Search {
 
     try {
       final response = await _client.get(
-        _buildChartsUrl(),
+        _buildChartsUrl(genreId: genreId),
       );
 
       final results = json.decode(response.data);
@@ -182,13 +183,15 @@ class Search {
     return buf.toString();
   }
 
-  String _buildChartsUrl() {
+  String _buildChartsUrl({int genreId}) {
     final buf = StringBuffer(FEED_API_ENDPOINT);
 
     buf.write('/');
     buf.write(_country.countryCode.toLowerCase());
     buf.write('/rss/toppodcasts/limit=');
     buf.write(_limit);
+    if(genreId != null)
+      buf.write('/genre=$genreId');
     buf.write('/explicit=');
     buf.write(_explicit);
     buf.write('/json');

--- a/podcast_search.iml
+++ b/podcast_search.iml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>


### PR DESCRIPTION
I added the ability to pass in a genre ID to the `charts` function so that you can get the top podcasts by genre.