### PR TITLE
Support podcast index 2.0 value tag

### DIFF
--- a/lib/podcast_search.dart
+++ b/lib/podcast_search.dart
@@ -13,3 +13,4 @@ export 'src/model/podcast.dart';
 export 'src/model/search_result.dart';
 export 'src/search/providers/providers.dart';
 export 'src/search/search.dart';
+export 'src/model/value.dart';

--- a/lib/src/model/item.dart
+++ b/lib/src/model/item.dart
@@ -167,7 +167,7 @@ class Item {
 
     var valueJson = json['value'];
     Value value;
-    if (valueJson != null) {
+    if (valueJson != null && valueJson is Map) {
       value = Value.fromJson(valueJson);
     }
 

--- a/lib/src/model/item.dart
+++ b/lib/src/model/item.dart
@@ -4,6 +4,7 @@
 import 'package:meta/meta.dart';
 import 'package:podcast_search/podcast_search.dart';
 import 'package:podcast_search/src/model/genre.dart';
+import 'package:podcast_search/src/model/value.dart';
 
 /// A class that represents an individual Podcast within the search results. Not all
 /// properties may contain values for all search providers.
@@ -85,6 +86,9 @@ class Item {
   /// Full list of genres for the podcast.
   final List<Genre> genre;
 
+  // the value tag of the podcast.
+  final Value value;
+
   Item({
     this.artistId,
     this.collectionId,
@@ -112,6 +116,7 @@ class Item {
     this.primaryGenreName,
     this.contentAdvisoryRating,
     this.genre,
+    this.value,
   });
 
   /// Takes our json map and builds a Podcast instance from it.
@@ -156,8 +161,14 @@ class Item {
     var categories = json['categories'];
     var genres = <Genre>[];
 
-    if (categories != null) {
+    if (categories != null && categories is Map<String, dynamic>) {
       categories.forEach((key, value) => genres.add(Genre(int.parse(key), value)));
+    }
+
+    var valueJson = json['value'];
+    Value value;
+    if (valueJson != null) {
+      value = Value.fromJson(valueJson);
     }
 
     return Item(
@@ -168,6 +179,7 @@ class Item {
       artworkUrl: json['image'] as String,
       genre: genres,
       releaseDate: DateTime.fromMillisecondsSinceEpoch(pubDate.inMilliseconds),
+      value: value,
     );
   }
 

--- a/lib/src/model/value.dart
+++ b/lib/src/model/value.dart
@@ -17,6 +17,10 @@ class Value {
     }
     return Value(model, destinations);
   }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{'model': model.toJson(), 'destinations': destinations.map((d) => d.toJson()).toList()};
+  }
 }
 
 class ValueModel {
@@ -29,13 +33,17 @@ class ValueModel {
   static ValueModel fromJson(Map<String, dynamic> json) {
     return ValueModel(type: json['type'] as String, method: json['method'] as String, suggested: json['suggested'] as String);
   }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{'type': type, 'method': method, 'suggested': suggested};
+  }
 }
 
 class ValueDestination {
   final String name;
   final String address;
   final String type;
-  final num split;
+  final double split;
 
   ValueDestination({this.name, this.address, this.type, this.split});
 
@@ -48,7 +56,11 @@ class ValueDestination {
       name: json['name'] as String,
       address: json['address'] as String,
       type: json['type'] as String,
-      split: split as num,
+      split: (split as num).toDouble(),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{'name': name, 'address': address, 'type': type, 'split': split};
   }
 }

--- a/lib/src/model/value.dart
+++ b/lib/src/model/value.dart
@@ -1,0 +1,54 @@
+class Value {
+  final ValueModel model;
+  final List<ValueDestination> destinations;
+
+  Value(this.model, this.destinations);
+
+  static Value fromJson(Map<String, dynamic> json) {
+    final model = ValueModel.fromJson(json['model']);
+    final destinations = <ValueDestination>[];
+    final destinationsJson = json['destinations'];
+    if (destinationsJson is List) {
+      destinationsJson.forEach((d) {
+        if (d is Map<String, dynamic>) {
+          destinations.add(ValueDestination.fromJson(d));
+        }
+      });
+    }
+    return Value(model, destinations);
+  }
+}
+
+class ValueModel {
+  final String type;
+  final String method;
+  final String suggested;
+
+  ValueModel({this.type, this.method, this.suggested});
+
+  static ValueModel fromJson(Map<String, dynamic> json) {
+    return ValueModel(type: json['type'] as String, method: json['method'] as String, suggested: json['suggested'] as String);
+  }
+}
+
+class ValueDestination {
+  final String name;
+  final String address;
+  final String type;
+  final num split;
+
+  ValueDestination({this.name, this.address, this.type, this.split});
+
+  static ValueDestination fromJson(Map<String, dynamic> json) {
+    var split = json['split'];
+    if (split is String) {
+      split = double.tryParse(split);
+    }
+    return ValueDestination(
+      name: json['name'] as String,
+      address: json['address'] as String,
+      type: json['type'] as String,
+      split: split as num,
+    );
+  }
+}

--- a/lib/src/search/podcast_index_search.dart
+++ b/lib/src/search/podcast_index_search.dart
@@ -99,7 +99,7 @@ class PodcastIndexSearch extends BaseSearch {
     _explicit = explicit;
 
     try {
-      var response = await _client.get(_buildSearchUrl());
+      var response = await _client.get(buildSearchUrl());
 
       return SearchResult.fromJson(json: response.data, type: ResultType.podcastIndex);
     } on DioError catch (e) {
@@ -131,7 +131,7 @@ class PodcastIndexSearch extends BaseSearch {
 
   /// This internal method constructs a correctly encoded URL which is then
   /// used to perform the search.
-  String _buildSearchUrl() {
+  String buildSearchUrl() {
     final buf = StringBuffer(SEARCH_API_ENDPOINT);
 
     buf.write(_termParam());

--- a/test/podcast_index_2.0_test.dart
+++ b/test/podcast_index_2.0_test.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2019-2021, Ben Hills. Use of this source code is governed by a
+// MIT license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:podcast_search/podcast_search.dart';
+import 'package:test/test.dart';
+import 'package:podcast_search/src/search/podcast_index_search.dart';
+
+void main() {
+  group('Custom search test', () {
+    test('Podcast index 2.0 value test', () async {
+      final jsonMap = jsonDecode(
+          '{"model":{"type":"lightning","method":"keysend","suggested":"0.00000050000"},"destinations":[{"name":"podcaster","type":"node","address":"03dfa33ae4230eb83ed55e58bdc6882eea37e651cc08aafa108da1de923e7163f9","split":99.0},{"name":"Podcastindex.org","address":"03ae9f91a0cb8ff43840e3c322c4c61f019d8c1c3cea15a25cfc425ac605e61a4a","type":"node","split":1.0}]}');
+      final value = Value.fromJson(jsonMap);
+      final serialized = value.toJson();
+
+      expect(DeepCollectionEquality().equals(serialized, jsonMap), true);
+    });
+    test('Podcast index 2.0 test', () async {
+      final result = await CustomPodcastIndexSearch().search(term: 'Podcasting 2.0');
+      expect(result.items[0].value != null, true);
+    });
+  });
+}
+
+class CustomPodcastIndexSearch extends PodcastIndexSearch {
+  static String SEARCH_API_ENDPOINT = 'https://api.podcastindex.org/api/1.0/podcasts';
+
+  CustomPodcastIndexSearch()
+      : super(
+            timeout: 10000,
+            userAgent: 'test agent',
+            podcastIndexProvider:
+                PodcastIndexProvider(key: 'XXWQEGULBJABVHZUM8NF', secret: 'KZ2uy4upvq4t3e\$m\$3r2TeFS2fEpFTAaF92xcNdX'));
+
+  @override
+  String buildSearchUrl() {
+    return 'https://api.podcastindex.org/api/1.0/podcasts/bytag?podcast-value';
+  }
+}


### PR DESCRIPTION
This PR adds the "value" tag to podcast item search result as specified by podcast index 2.0 schema (https://github.com/Podcastindex-org/podcast-namespace).
The value tag defines the payment model of the item and supports lightning payments.
In addition I have modified the `_buildSearchUrl` method of PodcastIndexSearch to `buildSearchUrl` so it can be reused by only changing the url and demonstrated a way to use a custom search provider via a unit test.
The option of custom search provider is useful when the caller wants to use different API endpoints to search using podcast index and my intention is to use such custom provider when using anytime podcast app as a dependency inside Breez while I am avoiding significant changes to the low level library.