### PR TITLE
Implement charts for podcast index

### DIFF
--- a/lib/src/model/item.dart
+++ b/lib/src/model/item.dart
@@ -155,7 +155,8 @@ class Item {
   }
 
   static Item _fromPodcastIndex(Map<String, dynamic> json) {
-    int pubDateSeconds = json['lastUpdateTime'] ?? DateTime.now();
+    int pubDateSeconds =
+        json['lastUpdateTime'] ?? DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
     var pubDate = Duration(seconds: pubDateSeconds);
     var categories = json['categories'];

--- a/lib/src/search/base_search.dart
+++ b/lib/src/search/base_search.dart
@@ -13,15 +13,15 @@ abstract class BaseSearch {
   /// If an error occurs, this will contain a user-readable error message.
   String lastError;
 
-  Future<SearchResult> search({
-    @required String term,
-    Country country,
-    Attribute attribute,
-    Language language,
-    int limit,
-    int version = 0,
-    bool explicit = false,
-  });
+  Future<SearchResult> search(
+      {@required String term,
+      Country country,
+      Attribute attribute,
+      Language language,
+      int limit,
+      int version = 0,
+      bool explicit = false,
+      Map<String, dynamic> queryParams});
 
   Future<SearchResult> charts();
 

--- a/lib/src/search/itunes_search.dart
+++ b/lib/src/search/itunes_search.dart
@@ -71,15 +71,15 @@ class ITunesSearch extends BaseSearch {
   /// By default, searches will be based on keywords. Supply an [Attribute]
   /// value to search by a different attribute such as Author, genre etc.
   @override
-  Future<SearchResult> search({
-    String term,
-    Country country,
-    Attribute attribute,
-    Language language,
-    int limit,
-    int version = 0,
-    bool explicit = false,
-  }) async {
+  Future<SearchResult> search(
+      {String term,
+      Country country,
+      Attribute attribute,
+      Language language,
+      int limit,
+      int version = 0,
+      bool explicit = false,
+      Map<String, dynamic> queryParams = const {}}) async {
     _term = term;
     _country = country;
     _attribute = attribute;
@@ -89,7 +89,7 @@ class ITunesSearch extends BaseSearch {
     _explicit = explicit;
 
     try {
-      final response = await _client.get(_buildSearchUrl());
+      final response = await _client.get(_buildSearchUrl(queryParams));
 
       final results = json.decode(response.data);
 
@@ -169,7 +169,7 @@ class ITunesSearch extends BaseSearch {
 
   /// This internal method constructs a correctly encoded URL which is then
   /// used to perform the search.
-  String _buildSearchUrl() {
+  String _buildSearchUrl(Map<String, dynamic> queryParams) {
     final buf = StringBuffer(SEARCH_API_ENDPOINT);
 
     buf.write(_termParam());
@@ -180,6 +180,9 @@ class ITunesSearch extends BaseSearch {
     buf.write(_versionParam());
     buf.write(_explicitParam());
     buf.write(_standardParam());
+    queryParams.forEach((key, value) {
+      buf.write('&$key=${Uri.encodeComponent(value)}');
+    });
 
     return buf.toString();
   }

--- a/lib/src/search/podcast_index_search.dart
+++ b/lib/src/search/podcast_index_search.dart
@@ -19,6 +19,8 @@ import 'package:podcast_search/src/search/base_search.dart';
 class PodcastIndexSearch extends BaseSearch {
   static String SEARCH_API_ENDPOINT =
       'https://api.podcastindex.org/api/1.0/search';
+  static String TRENDING_API_ENDPOINT =
+      'https://api.podcastindex.org/api/1.0/podcasts/trending';
 
   PodcastIndexProvider podcastIndexProvider;
 
@@ -122,14 +124,25 @@ class PodcastIndexSearch extends BaseSearch {
   /// the infrequent update of the chart feed it is recommended that clients
   /// cache the results.
   @override
-  Future<SearchResult> charts({
-    Country country = Country.UNITED_KINGDOM,
-    int limit = 20,
-    bool explicit = false,
-    Genre genre,
-  }) async {
-    /// This should never be thrown as charts is only handled by iTunes for now.
-    throw UnimplementedError();
+  Future<SearchResult> charts(
+      {Country country = Country.UNITED_KINGDOM,
+      int limit = 20,
+      bool explicit = false,
+      Genre genre,
+      Map<String, dynamic> queryParams}) async {
+    try {
+      var response = await _client.get(TRENDING_API_ENDPOINT,
+          queryParameters: {
+            'since': -1 * 3600 * 24 * 7,
+          }..addAll(queryParams));
+
+      return SearchResult.fromJson(
+          json: response.data, type: ResultType.podcastIndex);
+    } on DioError catch (e) {
+      setLastError(e);
+    }
+
+    return SearchResult.fromError(_lastError, _lastErrorType);
   }
 
   /// This internal method constructs a correctly encoded URL which is then

--- a/lib/src/search/podcast_index_search.dart
+++ b/lib/src/search/podcast_index_search.dart
@@ -89,21 +89,21 @@ class PodcastIndexSearch extends BaseSearch {
   /// By default, searches will be based on keywords. Supply an [Attribute]
   /// value to search by a different attribute such as Author, genre etc.
   @override
-  Future<SearchResult> search({
-    String term,
-    Country country,
-    Attribute attribute,
-    Language language,
-    int limit,
-    int version = 0,
-    bool explicit = false,
-  }) async {
+  Future<SearchResult> search(
+      {String term,
+      Country country,
+      Attribute attribute,
+      Language language,
+      int limit,
+      int version = 0,
+      bool explicit = false,
+      Map<String, dynamic> queryParams = const {}}) async {
     _term = term;
     _limit = limit;
     _explicit = explicit;
 
     try {
-      var response = await _client.get(_buildSearchUrl());
+      var response = await _client.get(_buildSearchUrl(queryParams));
 
       return SearchResult.fromJson(
           json: response.data, type: ResultType.podcastIndex);
@@ -129,7 +129,7 @@ class PodcastIndexSearch extends BaseSearch {
       int limit = 20,
       bool explicit = false,
       Genre genre,
-      Map<String, dynamic> queryParams}) async {
+      Map<String, dynamic> queryParams = const {}}) async {
     try {
       var response = await _client.get(TRENDING_API_ENDPOINT,
           queryParameters: {
@@ -147,12 +147,15 @@ class PodcastIndexSearch extends BaseSearch {
 
   /// This internal method constructs a correctly encoded URL which is then
   /// used to perform the search.
-  String _buildSearchUrl() {
+  String _buildSearchUrl(Map<String, dynamic> queryParams) {
     final buf = StringBuffer(SEARCH_API_ENDPOINT);
 
     buf.write(_termParam());
     buf.write(_limitParam());
     buf.write(_explicitParam());
+    queryParams.forEach((key, value) {
+      buf.write('&$key=${Uri.encodeComponent(value)}');
+    });
 
     return buf.toString();
   }

--- a/lib/src/search/search.dart
+++ b/lib/src/search/search.dart
@@ -99,18 +99,34 @@ class Search {
   /// result for each item resulting in a HTTP call for each result. Given
   /// the infrequent update of the chart feed it is recommended that clients
   /// cache the results.
-  Future<SearchResult> charts({
-    Country country = Country.UNITED_KINGDOM,
-    int limit = 20,
-    bool explicit = false,
-    Genre genre,
-  }) async {
+  Future<SearchResult> charts(
+      {SearchProvider searchProvider = const ITunesProvider(),
+      Country country = Country.UNITED_KINGDOM,
+      int limit = 20,
+      bool explicit = false,
+      Genre genre,
+      Map<String, dynamic> queryParams}) async {
     _country = country;
     _limit = limit;
     _explicit = explicit;
     _genre = genre;
 
-    return ITunesSearch().charts(
+    if (searchProvider is PodcastIndexProvider) {
+      return PodcastIndexSearch(
+        userAgent: userAgent,
+        timeout: timeout,
+        podcastIndexProvider: searchProvider,
+      ).charts(
+          country: _country,
+          limit: _limit,
+          explicit: _explicit,
+          genre: _genre,
+          queryParams: queryParams);
+    }
+    return ITunesSearch(
+      userAgent: userAgent,
+      timeout: timeout,
+    ).charts(
         country: _country, limit: _limit, explicit: _explicit, genre: _genre);
   }
 

--- a/lib/src/search/search.dart
+++ b/lib/src/search/search.dart
@@ -50,16 +50,15 @@ class Search {
   /// podcasts available in a specific country by supplying a [Country] option.
   /// By default, searches will be based on keywords. Supply an [Attribute]
   /// value to search by a different attribute such as Author, genre etc.
-  Future<SearchResult> search(
-    String term, {
-    SearchProvider searchProvider = const ITunesProvider(),
-    Country country,
-    Attribute attribute,
-    Language language,
-    int limit,
-    int version = 0,
-    bool explicit = false,
-  }) async {
+  Future<SearchResult> search(String term,
+      {SearchProvider searchProvider = const ITunesProvider(),
+      Country country,
+      Attribute attribute,
+      Language language,
+      int limit,
+      int version = 0,
+      bool explicit = false,
+      Map<String, dynamic> queryParams = const {}}) async {
     _term = term;
     _country = country;
     _attribute = attribute;
@@ -76,18 +75,17 @@ class Search {
         : PodcastIndexSearch(
             userAgent: userAgent,
             timeout: timeout,
-            podcastIndexProvider: searchProvider,
-          );
+            podcastIndexProvider: searchProvider);
 
     return s.search(
-      term: term,
-      country: _country,
-      attribute: _attribute,
-      language: _language,
-      limit: _limit,
-      version: _version,
-      explicit: _explicit,
-    );
+        term: term,
+        country: _country,
+        attribute: _attribute,
+        language: _language,
+        limit: _limit,
+        version: _version,
+        explicit: _explicit,
+        queryParams: queryParams);
   }
 
   /// Fetches the list of top podcasts

--- a/test/podcast_search_test.dart
+++ b/test/podcast_search_test.dart
@@ -19,7 +19,7 @@ void main() {
               secret: 'KZ2uy4upvq4t3e\$m\$3r2TeFS2fEpFTAaF92xcNdX'),
           queryParams: {'val': 'lightning'});
 
-      expect(result.resultCount, 1);
+      expect(result.resultCount > 0, true);
     });
 
     test('Max one result test', () async {

--- a/test/podcast_search_test.dart
+++ b/test/podcast_search_test.dart
@@ -12,6 +12,16 @@ void main() {
       search = Search();
     });
 
+    test('Podcast index trending', () async {
+      final result = await search.charts(
+          searchProvider: PodcastIndexProvider(
+              key: 'XXWQEGULBJABVHZUM8NF',
+              secret: 'KZ2uy4upvq4t3e\$m\$3r2TeFS2fEpFTAaF92xcNdX'),
+          queryParams: {'val': 'lightning'});
+
+      expect(result.resultCount, 1);
+    });
+
     test('Max one result test', () async {
       final result = await search.search('Forest 404');
 


### PR DESCRIPTION
This PR implements "charts" API for podcast index using  trending call.
In order to filter trending results the charts API was also modified to get additional query parameters that will be passed to podcast index endpoint.
Specifically in Breez we would like to use it to filter those that can be used with lightning payments and for that purpose we will pass  "val":"lightning" filter as introduced in the additional test I added.
Also a small fix for default 'lastUpdatedTime' was added.