### PR TITLE
Use author instead of ownerName

### DIFF
--- a/lib/src/model/item.dart
+++ b/lib/src/model/item.dart
@@ -167,7 +167,7 @@ class Item {
     }
 
     return Item(
-      artistName: json['ownerName'] as String,
+      artistName: json['author'] as String,
       trackName: json['title'] as String,
       feedUrl: json['url'] as String,
       trackViewUrl: json['link'] as String,


### PR DESCRIPTION
I think it is more accurate to get the author from the 'author' property.
Also from my research it is always returned in podcast index various search API while ownerName isn't.